### PR TITLE
Adds support for required bearer token

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,8 +28,9 @@ type BGG struct {
 	limiter Limiter
 
 	// I prefer not to use the cookie jar since this is simpler
-	cookies  []*http.Cookie
-	username string
+	cookies     []*http.Cookie
+	username    string
+	bearerToken string
 
 	lock sync.RWMutex
 }
@@ -132,6 +133,13 @@ func SetCookies(username string, c []*http.Cookie) OptionSetter {
 func SetLimiter(limiter Limiter) OptionSetter {
 	return func(bgg *BGG) {
 		bgg.limiter = limiter
+	}
+}
+
+// SetBearerToken set the token to use when accessing the BGG API
+func SetBearerToken(token string) OptionSetter {
+	return func(bgg *BGG) {
+		bgg.bearerToken = token
 	}
 }
 

--- a/collections.go
+++ b/collections.go
@@ -354,6 +354,9 @@ func (bgg *BGG) GetCollection(ctx context.Context, username string, options ...C
 	if err != nil {
 		return nil, fmt.Errorf("create request failed: %w", err)
 	}
+	if bgg.bearerToken != "" {
+		req.Header.Add("Authorization", "Bearer "+bgg.bearerToken)
+	}
 
 	bgg.requestCookies(req)
 

--- a/lists.go
+++ b/lists.go
@@ -159,6 +159,9 @@ func (bgg *BGG) TopPages(ctx context.Context, page int) ([]int64, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create request failed: %w", err)
 	}
+	if bgg.bearerToken != "" {
+		req.Header.Add("Authorization", "Bearer "+bgg.bearerToken)
+	}
 	resp, err := bgg.do(req)
 	if err != nil {
 		return nil, fmt.Errorf("get request failed: %w", err)

--- a/login.go
+++ b/login.go
@@ -29,6 +29,9 @@ func (bgg *BGG) Login(ctx context.Context, username, password string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create the request: %w", err)
 	}
+	if bgg.bearerToken != "" {
+		req.Header.Add("Authorization", "Bearer "+bgg.bearerToken)
+	}
 
 	req.Header.Add("content-type", "application/json")
 

--- a/person.go
+++ b/person.go
@@ -40,6 +40,9 @@ func (bgg *BGG) PersonImage(ctx context.Context, id int64) (*PersonImage, error)
 	if err != nil {
 		return nil, fmt.Errorf("create request failed: %w", err)
 	}
+	if bgg.bearerToken != "" {
+		req.Header.Add("Authorization", "Bearer "+bgg.bearerToken)
+	}
 
 	resp, err := bgg.do(req)
 	if err != nil {

--- a/plays.go
+++ b/plays.go
@@ -147,6 +147,9 @@ func (bgg *BGG) Plays(ctx context.Context, setter ...PlaysOptionSetter) (*Plays,
 	if err != nil {
 		return nil, fmt.Errorf("create request failed: %w", err)
 	}
+	if bgg.bearerToken != "" {
+		req.Header.Add("Authorization", "Bearer "+bgg.bearerToken)
+	}
 
 	resp, err := bgg.do(req)
 	if err != nil {

--- a/rank.go
+++ b/rank.go
@@ -47,6 +47,9 @@ func (bgg *BGG) myCollections(ctx context.Context, objectID int64) (*rankRespons
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the request: %w", err)
 	}
+	if bgg.bearerToken != "" {
+		req.Header.Add("Authorization", "Bearer "+bgg.bearerToken)
+	}
 
 	req.Header.Add("content-type", "application/json")
 	bgg.requestCookies(req)

--- a/search.go
+++ b/search.go
@@ -87,6 +87,9 @@ func (bgg *BGG) Search(ctx context.Context, query string, setter ...SearchOption
 	if err != nil {
 		return nil, fmt.Errorf("create request failed: %w", err)
 	}
+	if bgg.bearerToken != "" {
+		req.Header.Add("Authorization", "Bearer "+bgg.bearerToken)
+	}
 
 	resp, err := bgg.do(req)
 	if err != nil {

--- a/thing.go
+++ b/thing.go
@@ -290,6 +290,9 @@ func (bgg *BGG) GetThings(ctx context.Context, setters ...GetOptionSetter) ([]Th
 	if err != nil {
 		return nil, fmt.Errorf("create request failed: %w", err)
 	}
+	if bgg.bearerToken != "" {
+		req.Header.Add("Authorization", "Bearer "+bgg.bearerToken)
+	}
 
 	resp, err := bgg.do(req)
 	if err != nil {

--- a/user.go
+++ b/user.go
@@ -92,6 +92,9 @@ func (bgg *BGG) GetUser(ctx context.Context, username string) (*User, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create request failed: %w", err)
 	}
+	if bgg.bearerToken != "" {
+		req.Header.Add("Authorization", "Bearer "+bgg.bearerToken)
+	}
 
 	resp, err := bgg.do(req)
 	if err != nil {


### PR DESCRIPTION
The BGG XML API2 now requires the use of a Bearer token when accessing the API, even if not "login in", so this PR adds a simple adjustment to allow the token to be added to the Client struct. 

https://boardgamegeek.com/using_the_xml_api#toc10
https://boardgamegeek.com/thread/3492262/registration-and-authorization-coming-to-the-xml-a
https://boardgamegeek.com/thread/3577944/the-xml-apicalypse-is-coming